### PR TITLE
fix: Rhythmically incorrect audio at the beginning

### DIFF
--- a/abilities/music/commands.py
+++ b/abilities/music/commands.py
@@ -39,8 +39,7 @@ async def play(interaction: Interaction, song: str) -> None:
         return
 
     await interaction.response.defer()
-
-    audio_source = youtube.to_audio_source(song)
+    audio_source = await youtube.stream(song)
 
     if isinstance(guild.voice_client, discord.VoiceClient):
         voice_client = guild.voice_client

--- a/abilities/music/youtube.py
+++ b/abilities/music/youtube.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import subprocess
 from typing import IO
@@ -24,7 +26,7 @@ class BufferedAudioSource(discord.AudioSource):
     This allows the source to be buffered for up to one packet.
     """
 
-    def __init__(self, source: discord.AudioSource):
+    def __init__(self, source: discord.AudioSource) -> None:
         self.source = source
         self.peeked_packet: bytes | None = None
 

--- a/abilities/music/youtube.py
+++ b/abilities/music/youtube.py
@@ -1,3 +1,4 @@
+import asyncio
 import subprocess
 from typing import IO
 
@@ -15,6 +16,35 @@ class OpusAudioSource(discord.AudioSource):
 
     def is_opus(self) -> bool:
         return True
+
+
+class BufferedAudioSource(discord.AudioSource):
+    """
+    Wraps an existing AudioSource, with an additional "peek" method.
+    This allows the source to be buffered for up to one packet.
+    """
+
+    def __init__(self, source: discord.AudioSource):
+        self.source = source
+        self.peeked_packet: bytes | None = None
+
+    async def peek(self) -> bytes:
+        """
+        Waits for and returns the next packet from the AudioSource
+        without actually removing that packet from the AudioSource.
+        """
+        self.peeked_packet = self.read()
+        return self.peeked_packet
+
+    def read(self) -> bytes:
+        if self.peeked_packet is not None:
+            pp, self.peeked_packet = self.peeked_packet, None
+            return pp
+
+        return self.source.read()
+
+    def is_opus(self) -> bool:
+        return self.source.is_opus()
 
 
 def to_audio_source(song: str) -> discord.AudioSource:
@@ -56,3 +86,20 @@ def to_audio_source(song: str) -> discord.AudioSource:
     assert encoding_process.stdout
 
     return OpusAudioSource(encoding_process.stdout)
+
+
+async def stream(song: str) -> discord.AudioSource:
+    """
+    Initiates a YouTube download via yt-dlp and pipes that through
+    FFMPEG to convert it to the OPUS format.
+
+    Then, waits until the first OPUS packet to be ready for upload to Discord.
+
+    Finally, returns a discord.AudioSource for the song.
+    """
+    audio_source = await asyncio.to_thread(to_audio_source, song)
+
+    buffered_audio_source = BufferedAudioSource(audio_source)
+    await buffered_audio_source.peek()
+
+    return buffered_audio_source

--- a/abilities/music/youtube.py
+++ b/abilities/music/youtube.py
@@ -28,7 +28,7 @@ class BufferedAudioSource(discord.AudioSource):
         self.source = source
         self.peeked_packet: bytes | None = None
 
-    async def peek(self) -> bytes:
+    def peek(self) -> bytes:
         """
         Waits for and returns the next packet from the AudioSource
         without actually removing that packet from the AudioSource.
@@ -100,6 +100,6 @@ async def stream(song: str) -> discord.AudioSource:
     audio_source = await asyncio.to_thread(to_audio_source, song)
 
     buffered_audio_source = BufferedAudioSource(audio_source)
-    await buffered_audio_source.peek()
+    await asyncio.to_thread(buffered_audio_source.peek)
 
     return buffered_audio_source


### PR DESCRIPTION
When you play a song, it sounds 'sped up' for a few seconds, before equalizing.

This is because the bot connects to the voice channel far before actually uploading any audio. Once it does finally start uploading audio, Discord needs to play it back at a higher speed in order to catch-up with the lost time.

Specifically, the timeline looks like this right now:
1. bot starts downloading youtube video
2. bot sets up the youtube -> ffmpeg stream
3. bot connects to voice channel
4. a couple seconds pass
5. ffmpeg finally starts producing some output, and bot uploads that to discord
6. discord replays the new audio 10% faster in order to catch up to real-time (because a few seconds were lost in step 4)

This PR moves step (3) to after step (5).

Also, fixes https://github.com/GabeMillikan/Pax-Virtuoso/issues/13