### PR TITLE
fix: Duplicate Spotify API request

### DIFF
--- a/abilities/music/streaming/spotify.py
+++ b/abilities/music/streaming/spotify.py
@@ -50,7 +50,7 @@ class SpotifyTrackMetadata:
             release_date = track_dict["album"]["release_date"]
 
             artist_names = [artist["name"] for artist in track_dict["artists"]]
-        except Exception as e:
+        except KeyError as e:
             msg = "Track was in an unexpected format."
             raise InvalidTrack(msg) from e
 

--- a/abilities/music/streaming/spotify.py
+++ b/abilities/music/streaming/spotify.py
@@ -28,6 +28,54 @@ class SpotifyTrackMetadata:
     artist_url: str
     released_at: int  # unix timestamp
 
+    @classmethod
+    def from_track_dict(
+        cls: type[SpotifyTrackMetadata],
+        track_dict: dict,
+    ) -> SpotifyTrackMetadata:
+        try:
+            track_id = track_dict["id"]
+            title = track_dict["name"]
+            song_link = track_dict["external_urls"]["spotify"]
+            cover_art = max(
+                track_dict["album"]["images"], key=lambda img: img["height"]
+            )["url"]
+            artist_name = track_dict["artists"][0]["name"]
+            artist_url = track_dict["artists"][0]["external_urls"]["spotify"]
+            release_date = track_dict["album"]["release_date"]
+
+            artist_names = [artist["name"] for artist in track_dict["artists"]]
+        except Exception as e:
+            raise InvalidTrack("Track was in an unexpected format.") from e
+
+        if len(artist_names) <= 2:
+            # by {A}
+            # by {A} and {B}
+            joined_artist_names = " and ".join(artist_names)
+        else:
+            # by {A}, {B}, and {C}
+            artist_names[-1] = f"and {artist_names[-1]}"
+            joined_artist_names = ", ".join(artist_names)
+
+        track = cls(
+            youtube_search_term=f'"{title}" by {joined_artist_names}',
+            title=title,
+            track_id=track_id,
+            url=song_link,
+            image_url=cover_art,
+            artist_name=artist_name,
+            artist_url=artist_url,
+            released_at=int(
+                datetime.fromisoformat(
+                    release_date if "-" in release_date else f"{release_date}-01-01"
+                )
+                .replace(tzinfo=timezone.utc)
+                .timestamp(),
+            ),
+        )
+
+        return track
+
 
 @dataclass
 class Song(BaseSong):
@@ -54,68 +102,65 @@ def extract_track_id(song: str) -> str | None:
     return result.group(1) if result else None
 
 
-async def get_song_name_from_track_id(track_id: str) -> SpotifyTrackMetadata:
+async def search(query: str) -> list[SpotifyTrackMetadata]:
+    """
+    Returns a dictionary mapping matched track IDs to f"{track title} by {track author(s)}"
+    """
+    result = await asyncio.to_thread(spotify_client.search, query)
+    if not result or "tracks" not in result or "items" not in result["tracks"]:
+        return []
+
+    tracks = [
+        SpotifyTrackMetadata.from_track_dict(track_dict)
+        for track_dict in result["tracks"]["items"]
+    ]
+
+    # Remove duplicate search results (which appear surprisingly often??)
+    seen_youtube_search_terms = set()
+    seen_track_ids = set()
+    unique_tracks: list[SpotifyTrackMetadata] = []
+    for track in tracks:
+        if (
+            track.youtube_search_term not in seen_youtube_search_terms
+            and track.track_id not in seen_track_ids
+        ):
+            unique_tracks.append(track)
+
+        seen_youtube_search_terms.add(track.youtube_search_term)
+        seen_track_ids.add(track.track_id)
+
+    return unique_tracks
+
+
+async def get_metadata_by_track_id(track_id: str) -> SpotifyTrackMetadata:
+
     try:
-        track = await asyncio.to_thread(spotify_client.track, track_id)
+        track_dict = await asyncio.to_thread(spotify_client.track, track_id)
     except Exception as e:
         msg = f"Spotify raised API error. {e!r}"
         raise InvalidTrack(msg) from e
 
-    if not track or "name" not in track or "artists" not in track:
-        msg = "Invalid Track ID"
+    if not track_dict:
+        msg = f"Invalid track ID {track_id}"
         raise InvalidTrack(msg)
 
-    try:
-        title = track["name"]
-        song_link = track["external_urls"]["spotify"]
-        cover_art = max(track["album"]["images"], key=lambda img: img["height"])["url"]
-        artist_name = track["artists"][0]["name"]
-        artist_url = track["artists"][0]["external_urls"]["spotify"]
-        release_date = track["album"]["release_date"]
-    except Exception as e:
-        msg = "Track returned unexpected JSON structure."
-        raise InvalidTrack(msg) from e
-
-    artist_names = ", ".join(
-        artist["name"] for artist in track["artists"] if "name" in artist
-    )
-
-    return SpotifyTrackMetadata(
-        youtube_search_term=f"{title} by {artist_names}",
-        title=title,
-        track_id=track_id,
-        url=song_link,
-        image_url=cover_art,
-        artist_name=artist_name,
-        artist_url=artist_url,
-        released_at=int(
-            datetime.fromisoformat(release_date)
-            .replace(tzinfo=timezone.utc)
-            .timestamp(),
-        ),
-    )
+    return SpotifyTrackMetadata.from_track_dict(track_dict)
 
 
-async def get_song_name(song: str) -> SpotifyTrackMetadata:
-    result = spotify_client.search(song)
-    if not result:
+async def get_metadata(query: str) -> SpotifyTrackMetadata:
+    tracks = await search(query)
+    if not tracks:
         msg = "Spotify API did not return any results."
         raise InvalidTrack(msg)
 
-    try:
-        track_id = result["tracks"]["items"][0]["id"]
-    except Exception:
-        msg = "Search returned unexpected JSON structure."
-        raise InvalidTrack(msg) from None
-
-    return await get_song_name_from_track_id(track_id)
+    return tracks[0]
 
 
 async def fetch(song: str) -> Song:
     if track_id := extract_track_id(song):
-        meta = await get_song_name_from_track_id(track_id)
+        meta = await get_metadata_by_track_id(track_id)
     else:
-        meta = await get_song_name(song)
+        meta = await get_metadata(song)
 
     youtube_song = await youtube.fetch(meta.youtube_search_term)
     return Song(

--- a/abilities/music/streaming/spotify.py
+++ b/abilities/music/streaming/spotify.py
@@ -42,7 +42,8 @@ class SpotifyTrackMetadata:
             title = track_dict["name"]
             song_link = track_dict["external_urls"]["spotify"]
             cover_art = max(
-                track_dict["album"]["images"], key=lambda img: img["height"]
+                track_dict["album"]["images"],
+                key=lambda img: img["height"],
             )["url"]
             artist_name = track_dict["artists"][0]["name"]
             artist_url = track_dict["artists"][0]["external_urls"]["spotify"]
@@ -50,7 +51,8 @@ class SpotifyTrackMetadata:
 
             artist_names = [artist["name"] for artist in track_dict["artists"]]
         except Exception as e:
-            raise InvalidTrack("Track was in an unexpected format.") from e
+            msg = "Track was in an unexpected format."
+            raise InvalidTrack(msg) from e
 
         if len(artist_names) <= 2:
             # by {A}
@@ -71,7 +73,7 @@ class SpotifyTrackMetadata:
             artist_url=artist_url,
             released_at=int(
                 datetime.fromisoformat(
-                    release_date if "-" in release_date else f"{release_date}-01-01"
+                    release_date if "-" in release_date else f"{release_date}-01-01",
                 )
                 .replace(tzinfo=timezone.utc)
                 .timestamp(),

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 black==23.9.1
+cachetools==5.3.1
 discord.py[voice]==2.3.2
 opuslib==3.0.1
 pip-tools==7.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ brotli==1.1.0
     # via yt-dlp
 build==1.0.3
     # via pip-tools
+cachetools==5.3.1
+    # via -r requirements.in
 certifi==2023.7.22
     # via
     #   requests


### PR DESCRIPTION
Right now, we first search spotify to find the track we want, then fetch that track's page. This is pretty wasteful since all of the track information is actually returned from the initial search.

Essentially, his PR replaces `Metadata(fetch_track(result["tracks"][0]["id"]))` with `Metadata(result["tracks"][0])`.

I've also added caching so that we don't request the same song twice within the same 15 minutes (which becomes useful in #30).