### PR TITLE
feat: autocomplete song names

### DIFF
--- a/abilities/music/commands.py
+++ b/abilities/music/commands.py
@@ -14,6 +14,24 @@ MAXIMUM_VOLUME = 150  # percent
 playback_volume = 1.0
 
 
+async def song_autocomplete(
+    interaction: discord.Interaction,
+    current: str,
+) -> list[app_commands.Choice[str]]:
+    current = current.strip()
+    if not current:
+        return []
+
+    tracks = await spotify.search(current)
+    return [
+        app_commands.Choice(
+            name=track.youtube_search_term[:100],
+            value=track.url if len(track.url) < 100 else track.title[:100],
+        )
+        for track in tracks[:10]
+    ]
+
+
 @tree.command(description="Sets the volume")
 @app_commands.describe(volume="The volume to play at, such as '50' for half volume.")
 async def volume(interaction: Interaction, volume: float) -> None:
@@ -43,6 +61,9 @@ async def volume(interaction: Interaction, volume: float) -> None:
 
 @tree.command(description="Plays a song")
 @app_commands.describe(song="The URL or name of a song from YouTube or Spotify.")
+@app_commands.autocomplete(
+    song=song_autocomplete,
+)
 @app_commands.choices(
     platform=[
         app_commands.Choice(name="YouTube", value="youtube"),

--- a/abilities/music/commands.py
+++ b/abilities/music/commands.py
@@ -15,7 +15,7 @@ playback_volume = 1.0
 
 
 async def song_autocomplete(
-    interaction: discord.Interaction,
+    interaction: discord.Interaction,  # noqa
     current: str,
 ) -> list[app_commands.Choice[str]]:
     current = current.strip()

--- a/abilities/music/streaming/spotify.py
+++ b/abilities/music/streaming/spotify.py
@@ -27,7 +27,7 @@ class SpotifyTrackMetadata:
     title: str
     track_id: str
     url: str
-    image_url: str
+    image_url: str | None
     artist_name: str
     artist_url: str
     released_at: int  # unix timestamp
@@ -41,10 +41,14 @@ class SpotifyTrackMetadata:
             track_id = track_dict["id"]
             title = track_dict["name"]
             song_link = track_dict["external_urls"]["spotify"]
-            cover_art = max(
-                track_dict["album"]["images"],
-                key=lambda img: img["height"],
-            )["url"]
+            if track_dict["album"]["images"]:
+                cover_art = max(
+                    track_dict["album"]["images"],
+                    key=lambda img: img["height"],
+                )["url"]
+            else:
+                cover_art = None
+
             artist_name = track_dict["artists"][0]["name"]
             artist_url = track_dict["artists"][0]["external_urls"]["spotify"]
             release_date = track_dict["album"]["release_date"]
@@ -179,7 +183,7 @@ async def fetch(song: str) -> Song:
         artist=meta.artist_name,
         artist_url=meta.artist_url,
         url=meta.url,
-        image_url=meta.image_url,
+        image_url=meta.image_url or youtube_song.image_url,
         duration=youtube_song.duration,
         released_at=meta.released_at,
         stream=youtube_song.stream,


### PR DESCRIPTION
This PR introduces a new feature that allows song autocomplete functionality in the music commands. It also modifies the `SpotifyTrackMetadata` class to handle cases where the album cover art is not available.

![image](https://github.com/GabeMillikan/Pax-Virtuoso/assets/44247924/ed1adc9a-5500-476f-835a-44b09c5cc11e)