### PR TITLE
Enhance Testing Environment

### DIFF
--- a/tests/music/test_common.py
+++ b/tests/music/test_common.py
@@ -96,7 +96,7 @@ def test_postprocess_packet(
     expected_output: bytes,
     message: str,
 ) -> None:
-    source = BufferedOpusAudioSource(io.BytesIO(b"".join(packets)))
+    source = BufferedOpusAudioSource(io.BytesIO(b""))
     source.volume = volume
 
     output = None

--- a/tests/music/test_common.py
+++ b/tests/music/test_common.py
@@ -10,7 +10,6 @@ import pytest
 repository_directory = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(repository_directory))
 
-
 from abilities.music.streaming.common import BufferedOpusAudioSource  # noqa
 
 OPUS_HEADERS = [
@@ -51,7 +50,7 @@ def test_db_gain(volume: float, expected: tuple[float, str]) -> None:
     source = BufferedOpusAudioSource(io.BytesIO(b""))
     source.volume = volume
     expected_db_gain, message = expected
-    assert source.db_gain == expected_db_gain, message
+    assert source.db_gain == pytest.approx(expected_db_gain), message
 
 
 @pytest.mark.parametrize(
@@ -85,7 +84,7 @@ def test_db_gain(volume: float, expected: tuple[float, str]) -> None:
         # volume changes
         (
             0.5,
-            [*OPUS_HEADERS, *FULL_VOLUME_PACKETS],
+            OPUS_HEADERS + FULL_VOLUME_PACKETS,
             HALF_VOLUME_PACKETS[-1],
             "Volume halved, packet should be halved",
         ),
@@ -97,7 +96,7 @@ def test_postprocess_packet(
     expected_output: bytes,
     message: str,
 ) -> None:
-    source = BufferedOpusAudioSource(io.BytesIO(b""))
+    source = BufferedOpusAudioSource(io.BytesIO(b"".join(packets)))
     source.volume = volume
 
     output = None


### PR DESCRIPTION
This PR modifies the test cases in `test_common.py` for the `BufferedOpusAudioSource` class. The changes include the use of `pytest.approx` for floating point comparison, the concatenation of two lists using the '+' operator instead of the '*' operator, and the initialization of `BufferedOpusAudioSource` with a byte string joined from packets.